### PR TITLE
Consolidate workspace CLAUDE.md with accurate ecosystem info

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ The `docs/` directory contains ecosystem-wide documentation:
 | Doc | Purpose |
 |-----|---------|
 | `ARCHITECTURE.md` | System architecture and dependency graph |
-| `VISION.md` | Project vision and 7 major goals |
+| `VISION.md` | Project vision and major goals |
 | `STATUS.md` | Current project status (keep updated) |
 | `LOCAL_SETUP.md` | Local dev setup — Docker, Poetry, services |
 | `COGNITIVE_LOOP.md` | Perception → reasoning → planning → action loop |
@@ -72,7 +72,7 @@ The `docs/` directory contains ecosystem-wide documentation:
 | `TESTING.md` | Testing strategy — unit, integration, E2E |
 | `OBSERVABILITY.md` | OpenTelemetry, Jaeger, Grafana |
 | `PROJECT_TRACKING.md` | Issue tracking, epics, label conventions |
-| `PACKAGE_PUBLISHING.md` | Publishing logos-foundry to PyPI |
+| `PACKAGE_PUBLISHING.md` | Publishing logos-foundry packages |
 | `plans/` | Design docs and implementation specs |
 
 ---


### PR DESCRIPTION
## Summary

- Update the workspace `CLAUDE.md` from a thin ecosystem router to a complete operational guide
- Adds Redis as infrastructure dependency (port 6379)
- Adds inter-service communication section (EventBus, REST APIs)
- Adds workspace-level tools table (`pull_all.sh`, `reconcile-issues.sh`)
- Adds docs directory inventory
- Fixes lint command: `ruff check` + `black` (was `ruff format`)
- Replaces `AGENTS.md` pointers with `CLAUDE.md` pointers
- Streamlines agent guidance sections

Closes #<issue-number>

## Test plan

- [ ] Verify CLAUDE.md renders correctly on GitHub
- [ ] Confirm port numbers match `logos_config/ports.py`
- [ ] Confirm docs table matches actual `docs/` contents
- [ ] Confirm tools table matches actual scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)