### PR TITLE
docs: refresh STATUS / VISION / COGNITIVE_LOOP for MTS framing

### DIFF
--- a/docs/COGNITIVE_LOOP.md
+++ b/docs/COGNITIVE_LOOP.md
@@ -1,6 +1,25 @@
 # Cognitive Loop — What It Does and Doesn't Do
 
-An honest accounting of the cognitive loop feature, covering the initial implementation (logos #490/#491, sophia #125/#127, hermes #82/#84) and the performance sprint (sophia #128/#131, hermes #85, apollo #161, logos #492). Updated 2026-02-28.
+An honest accounting of the cognitive loop feature, covering the initial implementation (logos #490/#491, sophia #125/#127, hermes #82/#84) and the performance sprint (sophia #128/#131, hermes #85, apollo #161, logos #492). Updated 2026-05-30 against the 2026-05-29 code-grounded audit.
+
+> **Scope note.** This documents the *ingestion* arc of the loop — extract → store
+> → retrieve context → enrich the LLM prompt. That arc is built and runs, but it
+> is **not** the full cognitive loop the vision describes: there is no autonomous
+> reasoning, feedback does not mutate the graph, and Sophia runs request/response
+> rather than as a persistent event-driven process. Building the rest is the work
+> of the six MTS sprints (`docs/plans/2026-05-29-roadmap-to-mts.md`).
+>
+> **Keystone caveat (read before trusting "embeddings written to Milvus" below).**
+> The audit found embeddings **silently fail to persist** — the `hcg_*_embeddings`
+> Milvus collections read 0 in the live flow. Sophia swallows the write failure in
+> a warn-only `try/except` (`sophia/src/sophia/ingestion/proposal_processor.py:519-524`),
+> and the logos Milvus sync is insert-only against an `auto_id` PK
+> (`logos/logos_hcg/sync.py:155,315,365`), so re-syncs append duplicates instead of
+> upserting. With no retrievable vectors, the type classifier degrades to the
+> fallback type and #505 emergence loads 0 members. This is the Sprint-1 keystone
+> (sophia#146 depends-on logos#528). Where this document says an embedding is
+> "written to Milvus" as a working side effect, treat it as *attempted but
+> currently a no-op* until that fix lands.
 
 ## The End-to-End Flow
 
@@ -79,8 +98,10 @@ Hermes POST /llm
 | HCG Client `query_neighbors()` | Working | Bidirectional traversal through reified edges |
 | Milvus dedup (ENTITY_MATCH_THRESHOLD=0.5) | Working | L2 distance check, entities below threshold are skipped |
 | Context retrieval | Working | Searches 5 Milvus collections (Entity, Concept, State, Process, Edge), top 10 by L2 score |
-| Feedback dispatch to Redis | Working | Enqueues FeedbackPayload via LPUSH, worker dequeues via BRPOP |
+| Feedback dispatch to Redis | Working (transport only) | Enqueues FeedbackPayload via LPUSH, worker dequeues via BRPOP. **The payload then goes nowhere** — `/feedback` is a stub (see below); making feedback mutate the graph is Sprint 2 |
 | Feedback worker | Working | Retries with exponential backoff, max 5 attempts, dead-letter queue |
+| Inter-service event bus (`logos_events`) | Working, on main | Centralized Redis pub/sub (logos #519) carries **real** inter-service traffic — Sophia publishes ontology events, Hermes subscribes for runtime type sync (sophia #501). Earlier docs claimed the bus carried no inter-service traffic; that is no longer true |
+| Maintenance scheduler | Wired, on main | sophia #508 — runs as a process, but the reasoning jobs it would dispatch (#503/#504/#506) are unbuilt, so it currently does ~nothing |
 | Edge processing | Working | Resolves entity names to UUIDs, creates reified edge nodes in Neo4j, stores edge embeddings in Milvus "Edge" collection |
 | Experiment tracking | Working | Creates experiment_run nodes with PRODUCED edges to track pipeline configuration and outputs |
 | Batch proposal processing | Working | Proposals are batched and processed in parallel (sophia #131), reducing per-proposal overhead |
@@ -152,15 +173,20 @@ The original task queue (from PR #490) listed several pending items. Current sta
 | `/ingest/hermes_proposal` endpoint | Unit (5 tests) | Processor is None (not initialized), so only tests the HTTP layer, not actual processing |
 | HCG Client `add_node`, `add_edge` | Unit | Mock Neo4j driver |
 
-### What's NOT tested
+> **Stale-claim correction (2026-05-30).** Earlier revisions of this section said
+> `ProposalBuilder` and the Hermes Sophia-integration path had *zero tests*. That
+> is no longer true: `hermes/tests/unit/test_proposal_builder.py` covers NER
+> extraction, entity proposal, pipeline metadata, graceful degradation, and the
+> combined-extractor pipeline (6 tests), and `test_llm_endpoint_dual_proposal.py`
+> exercises the `/llm` context-injection path. The rows below are updated to match.
+
+### What's NOT tested (or under-tested)
 
 | Component | Impact |
 |-----------|--------|
-| `ProposalBuilder` (hermes) | Zero tests. NER extraction, entity embedding, document embedding — all untested |
-| `_get_sophia_context()` (hermes) | Zero tests. The entire Sophia integration path — untested |
-| `_build_context_message()` (hermes) | Zero tests. Context formatting — untested |
-| Context injection in `/llm` | Zero tests. The message list mutation — untested |
-| Full pipeline (hermes → sophia → Neo4j → Milvus → context return) | Zero integration tests with real services |
+| `ProposalBuilder` (hermes) | **Now unit-tested** (`test_proposal_builder.py`, 6 tests). Real-service embedding/Milvus behavior still only exercised at the seam, not end-to-end |
+| `/llm` context injection (hermes) | **Now covered** by `test_llm_endpoint_dual_proposal.py`. The live Sophia round-trip is still mocked, not integration-tested |
+| Full pipeline (hermes → sophia → Neo4j → Milvus → context return) | Integration tests exist but are **vacuous** at the seam — `test_hermes_ingestion_integration.py:139` queries `{id: $proposal_id}` while nodes are stored with `uuid`, so it asserts nothing (S1-04 / logos#529). This is *why* the keystone embedding bug went undetected |
 | Feedback loop (sophia → Redis → worker → hermes) | Zero tests |
 | Milvus dedup with real embeddings | Zero tests. The L2 threshold of 0.5 is untested against real data |
 | SHACL validation rejecting a malformed node | Zero tests |
@@ -193,16 +219,20 @@ The original task queue (from PR #490) listed several pending items. Current sta
 
 ## What Expanding the Loop Looks Like
 
-The cognitive loop as shipped is the thinnest possible slice: extract entities → store in graph → retrieve as context → enrich LLM prompt. The main axes of expansion are:
+The cognitive loop as shipped is the thinnest possible slice: extract entities → store in graph → retrieve as context → enrich LLM prompt. Expanding it into the loop the vision describes is exactly the arc of the six **MTS sprints** (`docs/plans/2026-05-29-roadmap-to-mts.md`); the axes below map onto those sprints.
+
+0. **Stabilize the spine (Sprint 1, now)** — before adding anything, the keystone embedding-persistence bug (sophia#146 / logos#528) must land so vectors actually persist, the vacuous integration tests must assert real outcomes (logos#529), and #505 emergent-type discovery must merge live-verified. Don't build cognition on a foundation that's secretly a no-op.
 
 1. **Relationship extraction** — ✅ Implemented. Hermes extracts verb-mediated relations via spaCy and proposes edges with embeddings. Sophia resolves names to UUIDs and stores edges in Neo4j + Milvus. Future work: LLM-based extraction for more complex relationships.
 
-2. **Feedback processing** — Make the `/feedback` endpoint actually do something: update confidence scores, deprecate nodes, adjust the dedup threshold, trigger re-embedding.
+2. **Feedback processing (Sprint 2)** — Make the `/feedback` endpoint actually mutate the graph: update confidence scores, dedup/deprecate nodes, adjust the threshold, trigger re-embedding. Today it logs and discards.
 
-3. **Planning integration** — The `HCGPlanner` exists in the foundry but isn't invoked anywhere in the loop. A natural extension: after ingesting a proposal, Sophia checks if the new knowledge enables any pending goals and triggers planning.
+3. **Orchestrator + event-driven loop (Sprint 3)** — Sophia runs request/response today. Turn it into a persistent process reacting to bus events, with ≥1 daemon transforming a real signal. (Design: `docs/plans/2026-03-14-event-driven-cognitive-loop-design.md`.)
 
-4. **Context quality** — Current context is a flat bullet list. Could be structured (subgraph snippet, relationship paths, confidence-weighted), summarized (LLM-generated summary of relevant knowledge), or filtered (only return context above a confidence threshold).
+4. **K-lines / curiosity / CWM-E gain (Sprint 4)** — stimulus activates a constellation; non-activation emits curiosity; CWM-E state measurably modulates processing. The CWM-E state models exist; the mechanisms don't.
 
-5. **Multi-turn memory** — Currently each `/llm` call is independent. The `correlation_id` exists but isn't used to link turns into a conversation. Building conversation-level context would require tracking which proposals belong to the same session.
+5. **Memory tiers + planning integration (Sprint 5)** — knowledge promotes ephemeral→STM→LTM by criteria, and new knowledge enabling a goal triggers the `HCGPlanner` (which exists in the foundry but is **not invoked anywhere in the loop today**, and still co-exists with a planner stub, logos #403).
 
-6. **Talos integration** — Proposals from sensor data (camera frames, IMU readings) rather than just text. This connects the cognitive loop to the physical world via Talos.
+6. **Context quality / multi-turn memory** — richer context (subgraph snippets, confidence-weighted, summarized) and linking `/llm` turns via `correlation_id` into conversation-level context. Folds into Sprints 5–6.
+
+7. **Talos integration (Horizon 2)** — Proposals from sensor data (camera frames, IMU) rather than just text, connecting the loop to the physical world. Deliberately out of MTS scope.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,66 +1,167 @@
 # LOGOS Project Status
 
-**Generated:** 2026-05-25
-**Previous update:** 2026-04-05
-**Foundry Version:** v0.7.0 (all repos at v0.7.0; no new release this period)
+**Generated:** 2026-05-30
+**Previous update:** 2026-05-25
+**Foundry Version:** v0.7.1 (sophia/hermes pinned; apollo/talos still v0.5.0 — see S1-07)
+
+> **Source of truth.** This status is reconciled against the code on `main` plus
+> unmerged frontier branches, not against prose docs. Evidence trail:
+> `vault/10-projects/LOGOS/2026-05-29-ecosystem-audit.md` (code-grounded audit,
+> verified `file:line`) and `docs/plans/2026-05-29-roadmap-to-mts.md` (the MTS
+> roadmap + Sprint-1 tickets). The 2026-05-30 issue realignment
+> (`docs/plans/2026-05-30-issue-realignment.md`) carved the work into six MTS
+> sprints on GitHub.
 
 ---
 
-## What Changed Since April 5
+## The one-paragraph picture
 
-After the new-job pause, work resumed in late May with a focused **environment + test-stack infrastructure push**, plus a **diagnostic session** that surfaced a previously-undocumented runtime gap (see "Key Finding" below). No new service features landed; the period is infrastructure, developer-experience, and reconstruction.
+**The foundation is strong; the cognitive core is still largely spec.** What is
+built and solid: the service topology (5 repos, shared `logos_*` packages,
+ports, config), the reified HCG ontology model, the ingest pipeline
+(Hermes NER/embeddings → Sophia proposal processing → Neo4j + Milvus), the Redis
+event bus with live inter-service ontology sync, the maintenance scheduler, and
+the CI/test-stack/env tooling. What is **not** yet built: the autonomous
+reasoning that turns that pipeline into a mind — feedback that mutates the graph,
+the maintenance reasoning jobs, K-lines/curiosity/CWM-E gain, memory tiers, and
+the persistent event-driven loop. Crucially, the audit found the *built* spine is
+**silently broken at one load-bearing seam**: embeddings never durably persist,
+which starves the type classifier and emergence. That bug is the keystone of the
+near-term plan.
 
-### Recent Work (merged PRs since April 5)
-- **logos-workspace #8** (2026-05-24) — Idempotent env bootstrap for the LOGOS workspace (`bootstrap.sh`): toolchain (uv/Poetry/fnm), Python 3.12 pinning, per-repo extras, vendored webapp SDK build, config distribution.
-- **logos #524** (2026-05-24) — `copy_test_stacks.py`: distribute rendered test stacks from `infra/<repo>/` into downstream repos' `containers/`.
-- **sophia #143** (2026-05-24) — Add `otel` extra (`poetry install -E otel`).
-- **apollo #165** (2026-05-25) — Fix `run_apollo.sh` cold-start: fail loud + build vendored SDKs before webapp install.
-- **hermes #103** (~2026-04-05) — Restructure ML extras, harden publish-ml build (PyTorch CPU index).
-
-### In Flight (open PRs)
-- **logos #525** — `fix(infra): sync test-stack render template with hand-maintained outputs` (Redis service, offset host ports, `${NEO4J_PASSWORD}` bridge, neo4j 5.11.0 pin). **CI green, all review threads resolved — ready to merge.**
-- **logos-workspace #9** — `feat(bootstrap): add --check-config switch` (render by default, drift-check on demand). CI green.
-
-### Blocked
-- **logos #464** — [Sophia] Update M3 planning tests for flexible ontology (`status:blocked`). Gates Goal 5 (planning) progress; blocked on flexible-ontology downstream updates.
-
----
-
-## Key Finding: Apollo HCG/persona UI is empty (no ticket yet)
-
-A live-debug this session found apollo's dashboard shows **no graph and no persona entries, with no errors**. Root cause is **not** empty data or a connection fault:
-
-- Sophia starts (via `run_apollo.sh`), connects to Neo4j (`bolt://localhost:7687`), and **seeds successfully** on boot (pick-and-place, plan, persona).
-- apollo connects to the same Neo4j but reads labels Sophia **no longer writes**: `hcg_client.py` queries `:Entity`/`:Process`/`:State`/`:Plan`/`:StateHistory`, and `persona_store.py` reads `:PersonaEntry`. Grep confirms Sophia writes **none** of these as labels post-#490; persona is persisted as `cwm_e` CWM-state nodes via `CWMPersistence`.
-- Empty result sets aren't errors → blank UI, clean logs.
-
-This is the **documented-but-unstarted work of logos #496** ("Consolidate CWM modules into HCG ontology types and retire `logos_cwm_e`"), whose problem list literally includes *"Apollo's `PersonaEntry` schema drift"* and whose acceptance criteria include *"Apollo's `PersonaEntry` model reconciled with ontology definition"* — all unchecked. It got stranded when the CWM-consolidation track was deferred behind the KG-maintenance track. **Recommend filing an apollo-reader-reconciliation issue under #496** (draft prepared this session).
+**Where the milestone line sits.** Against the full vision (grounding,
+embodiment, the 13-paper program) this is an open-ended research program, not a
+finite backlog. Against the concrete near-term milestone — **Minimum Thinking
+Sophia (MTS)**, defined below — the project is roughly **35–40%**, and MTS is six
+sprints out (see `docs/plans/2026-05-29-roadmap-to-mts.md`).
 
 ---
 
-## Progress Against Vision Goals
+## Keystone finding: embeddings silently fail to persist
 
-1. **Complete the cognitive loop** — *in progress.* Maintenance **scaffolding** done (Redis/pub-sub #500, ontology pub/sub #501, scheduler #508), but the four reasoning jobs (#503–507) are all `todo`. The scheduler runs with essentially no jobs yet.
-2. **Grounding / physical knowledge** — *research active, integration deferred.* Unchanged this period (V-JEPA→CLIP PoC stands at txt_R@1 ≈ 0.371 vs 0.42 target).
-3. **Flexible ontology** — *in progress, partially stalled.* Reified model (#490) merged is the foundation. The CWM→ontology consolidation (#496) is **not started** and is the direct cause of the Apollo finding above. Also open: type_definition UUID migration (#515), capability catalog (#465), downstream propagation (#460/#461).
-4. **Memory and learning** — *not started.* Spec #415; depends on cognitive-loop maturity + testing sanity (#416).
-5. **Planning and execution** — *in progress / blocked.* Planner stub still co-exists with HCGPlanner (#403); blocked on flexible-ontology downstream (#460, #464).
-6. **Embodiment via Talos** — *paused* (deliberately deprioritized until cognition is solid).
-7. **Infrastructure & observability** — *in progress; active this period.* This session: env bootstrap (#8), test-stack render/copy pipeline (#524, #525), run_apollo cold-start (#165), sophia otel extra (#143). Remaining: test data seeder centralization (#481), developer scripts (#409), endpoint spans (#335/#338), cross-service OTel testing (#321).
-8. **Documentation & testing** — *in progress.* PM agent + planning docs rediscovered and STATUS refreshed (this doc). Remaining: onboarding guide (#135), OpenAPI contract tests (#91).
-9. **Situated cognitive agent** — *deferred* (#521; prereqs Goals 1/4/5/6).
+The audit's central finding, re-verified in current code:
+
+- Live flow has entity nodes in Neo4j but the `hcg_*_embeddings` Milvus
+  collections read **0**. Vector persistence is a no-op.
+- **Sophia side** (`sophia/src/sophia/ingestion/proposal_processor.py:519-524`):
+  the `batch_upsert_embeddings` call sits inside a warn-only `try/except` that
+  swallows failure — the pipeline keeps going and logs a `warning`.
+- **Logos side** (`logos/logos_hcg/sync.py:155`): the runtime Milvus schema uses
+  an `auto_id` INT64 primary key with `uuid` as a plain field, while
+  `upsert_embedding`/`batch_upsert_embeddings` call `collection.insert()`
+  (`sync.py:315,365`) — so a re-synced `uuid` **appends a duplicate** instead of
+  replacing, despite comments claiming upsert semantics. The init script
+  (`infra/init_milvus_collections.py`) ships a *contradictory* `uuid`-PK schema,
+  and the guard test encodes the init schema, so the divergence passes in CI.
+
+**Consequence:** with no retrievable vectors, the type classifier degrades to the
+fallback `'entity'` type for everything, and #505 emergent-type discovery loads 0
+cluster members → "no qualifying clusters." This single seam neuters the whole
+maintenance/emergence arm.
+
+**Tracked as the Sprint-1 keystone:** **sophia#146** (warn-only swallow at
+ingestion) depends on **logos#528** (upsert-by-uuid + schema reconciliation).
+Fix logos#528 first, then sophia#146.
 
 ---
 
-## Drift / Reconciliation
+## What's built and solid
 
-`scripts/reconcile-issues.sh` flags older open issues (mostly 2026-02/03) not reflected in the project board — e.g. logos #412 (event-driven reflection), #411 (hierarchical memory), #403 (deprecate planner_stub), #321/#335/#338/#339 (OTel gaps), #246/#264/#265/#267 (persona diary stack — legacy `logos_cwm_e`, subsumed by #496), and the maintenance stories #503–507. Worth a board/label pass at next vision review.
+| Area | State | Evidence |
+|------|-------|----------|
+| Service topology + shared packages | Solid | `logos_config`, `logos_hcg`, `logos_events`, ports, 5 repos wired |
+| Reified HCG ontology model | Solid | logos #490 merged on main (flexible-ontology migration) |
+| Ingest pipeline (Hermes → Sophia → Neo4j/Milvus) | Built, runs | `ProposalBuilder` (now tested), `ProposalProcessor`; **but** embeddings don't persist (keystone) |
+| Redis event bus + inter-service ontology sync | Built, on main | `logos_events.EventBus`; sophia #501 pub/sub publisher merged |
+| Maintenance scheduler | Built, on main | sophia #508 merged — runs, but the reasoning jobs it would dispatch (#503/#504/#506) are unbuilt |
+| Type classification via centroids | Built | sophia #129 / logos #494 — degrades to fallback while embeddings are empty (keystone) |
+| CI / test-stack render-and-copy / env bootstrap | Active, recent | logos #524, logos-workspace #8/#9, apollo #165, sophia #143 |
+
+## What's spec / in-flight / not started
+
+| Area | State | Tracking |
+|------|-------|----------|
+| Emergent type discovery (#505) | Built + unit-tested, **unmerged**, can't run live until keystone lands | `feat/505-emergent-type-discovery` (sophia), `feat/505-name-cluster` (hermes) — S1-05 |
+| Feedback that mutates the graph | Not started — `/feedback` is a stub that logs and returns | Sprint 2 (#499 epic, #503/#504/#506/#507) |
+| Maintenance reasoning jobs | Not started — scheduler has ~no jobs | Sprint 2 |
+| Orchestrator + persistent event-driven loop + daemons | Not started — Sophia is request/response | Sprint 3 (under-decomposed by design) |
+| K-lines / curiosity / CWM-E gain | Not started — CWM-E state models exist, mechanisms don't | Sprint 4 |
+| Memory tiers + planning-in-loop | Not started | Sprint 5 (#415 epic, #460/#464 et al.) |
+| CWM→ontology consolidation (retire `logos_cwm_e`) | Not started — root cause of the empty Apollo dashboard | logos #496 (Sprint 6 reconcile) |
+| Grounding / JEPA (CWM-G) | Research active, integration deferred (Horizon 2) | V-JEPA→CLIP PoC, txt_R@1 ≈ 0.371 vs 0.42 target |
+| Embodiment via Talos | Paused (Horizon 2) | deliberate |
 
 ---
 
-## Current Priorities (carried from VISION + this session)
+## Minimum Thinking Sophia (MTS) — the near-term milestone
 
-1. **Apollo reader reconciliation** (slice of #496) — get the dashboard surfacing seeded data; unblocks day-to-day use and validates the cognitive loop end-to-end.
-2. Cognitive-loop expansion — first KG-maintenance reasoning job (#503 entity resolution; design + plan ready).
-3. Flexible-ontology consolidation (#496 in full) + downstream propagation (#460/#461/#515).
-4. Merge the in-flight infra PRs (logos #525, logos-workspace #9); infra hardening (seeder #481, remaining standardization).
+MTS is the point where LOGOS stops being *infrastructure + a thin ingestion loop*
+and becomes *a small mind that runs*: given a stream of experience (text for now),
+Sophia **autonomously grows and maintains** a non-linguistic graph,
+**reasons/plans** over it, **learns from feedback**, runs as a **persistent
+event-driven loop**, and **surfaces its cognitive state in Apollo**. Everything
+past MTS — JEPA grounding, Talos embodiment, the situated multi-device agent, the
+efficiency program, the papers — is **Horizon 2**, deliberately out of scope here.
+
+### The six MTS sprints
+
+| # | Goal | Exit (abbrev.) | ~% after |
+|---|------|----------------|----------|
+| **1** | **Make the built spine actually run & be trusted** | ingest→embed→classify→emerge works on live infra; CI would catch a regression; #505 merged & live-verified | ~45% |
+| **2** | Close the feedback loop (Learning v0) | feedback mutates the graph; maintenance jobs run | ~55% |
+| **3** | Orchestrator + event-driven loop + daemons | Sophia runs as a persistent process reacting to bus events | ~65% |
+| **4** | K-lines + curiosity + CWM-E gain (Cognition v1) | stimulus activates a constellation; non-activation emits curiosity; gain modulates processing | ~75% |
+| **5** | Memory tiers + planning-in-loop | knowledge promotes ephemeral→STM→LTM; new knowledge triggers HCGPlanner | ~85% |
+| **6** | Demonstrate the thesis (MTS integration) | recorded end-to-end session, Apollo rendering goal→plan→diary→cognitive-state | **~95% = MTS** |
+
+Weight concentrates in Sprints 3–4 (the genuinely novel cognitive mechanisms).
+Sprints S3/S4 are intentionally under-decomposed on the board — decompose when
+they approach. Full detail and per-ticket ACs in
+`docs/plans/2026-05-29-roadmap-to-mts.md`.
+
+---
+
+## Sprint 1 — "Make the built spine actually run & be trusted"
+
+The active sprint. Goal: every component the audit found *built-but-secretly-broken
+or untested* is fixed and provably working end-to-end, and #505 lands
+live-verified. Critical path: **logos#528 → sophia#146 → {S1-04, S1-05}**.
+
+| Ticket | What | Issue | State |
+|--------|------|-------|-------|
+| S1-01 🔴 keystone | Embedding persistence silently fails at ingestion | **sophia#146** | open |
+| S1-02 🔴 | HCGMilvusSync can't upsert-by-uuid (auto_id PK) + schema divergence | **logos#528** | open |
+| S1-03 🟠 | Redis missing from CI test stacks (pub/sub never exercised) | folded into logos #526 | open |
+| S1-04 🟠 | De-vacuum integration tests + run them in CI | **logos#529** | open (5 prune PRs linked) |
+| S1-05 🟢 | Finish & merge #505 emergent type discovery, live-verified | logos #505 | in-progress |
+| S1-06 🟡 | FeedbackConfig default Hermes port 18000→17000 | folded into sophia #142 | open |
+| S1-07 🟡 | Cross-repo foundry sync (apollo/talos still v0.5.0) + workspace hygiene | **logos#530** | open |
+| S1-08 🟢 | Doc refresh (this document, VISION, COGNITIVE_LOOP, vault landing) | **logos#531** | in-progress |
+
+**Sprint exit (DoD):** seed the demo scenario → run a `/llm` turn mentioning new
+entities → confirm (a) embeddings land in Milvus, (b) the classifier assigns
+non-fallback types, (c) `type_emergence` mints ≥1 real emergent type, (d) Apollo's
+dashboard shows the result — and a CI run that **fails** if any of those breaks.
+
+---
+
+## Known live-data gotcha: empty Apollo dashboard
+
+Apollo's dashboard shows **no graph and no persona entries, with no errors**. Root
+cause is schema drift, not missing data: Apollo's `hcg_client.py` queries
+`:Entity`/`:Process`/`:State`/`:Plan` labels and `persona_store.py` reads
+`:PersonaEntry`, but Sophia no longer writes those as labels post-#490 (persona is
+persisted as `cwm_e` CWM-state nodes). Empty result sets aren't errors → blank UI,
+clean logs. This is the unstarted work of **logos #496** (consolidate CWM modules
+into HCG ontology types; reconcile Apollo's reader), slated for **Sprint 6**.
+
+---
+
+## Deferred manual step (not in this PR)
+
+The vault LOGOS landing/narrative still lists **old ports (18000/28000…) and dead
+monorepo paths** and should be re-pointed at the audit
+(`2026-05-29-ecosystem-audit.md`) and the MTS roadmap. The vault is edited through
+a separate tool, not from this repo, so per S1-08 that update is left as a manual
+follow-up for the maintainer. This PR refreshes only the in-repo workspace docs
+(`docs/STATUS.md`, `docs/VISION.md`, `docs/COGNITIVE_LOOP.md`).

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -1,5 +1,17 @@
 # LOGOS Vision
 
+> **Reading this against the code.** This document states the *full* vision — an
+> open-ended research program. For where the code actually stands today (roughly
+> 35–40% of the near-term vision; foundation strong, cognitive core largely spec),
+> read `docs/STATUS.md`. The concrete near-term milestone is **Minimum Thinking
+> Sophia (MTS)** — the point where LOGOS becomes a small mind that runs: it grows
+> and maintains its graph, reasons/plans over it, learns from feedback, runs as a
+> persistent loop, and surfaces its state in Apollo. MTS is six sprints out; the
+> plan is `docs/plans/2026-05-29-roadmap-to-mts.md`. Everything past MTS
+> (grounding, embodiment, the situated agent, the papers) is **Horizon 2**.
+> Aspirational capabilities below are marked; goal status lines reflect the
+> 2026-05-29 code-grounded audit.
+
 ## What LOGOS Is
 
 LOGOS is a non-linguistic cognitive architecture built on a core assertion: **text is a poor substrate for thought.** Language models trained on text lack the grounded common sense that comes from non-linguistic experience. LOGOS addresses this by separating cognition from language entirely.
@@ -8,7 +20,7 @@ Sophia (the cognitive core) reasons over a knowledge graph (HCG) where nodes, ed
 
 Grounded understanding comes from JEPA (Joint Embedding Predictive Architecture) models that learn physical/sensory representations without text. These form the Grounded working memory (CWM-G) — a layer of common sense that language models fundamentally cannot provide. The Abstract working memory (CWM-A) captures conceptual and relational knowledge. The Emotional working memory (CWM-E) tracks emotional and persona states. All three are aspects of the same graph, not separate systems.
 
-Planning is a core capability. The HCGPlanner performs backward-chaining over REQUIRES/CAUSES edges to produce executable plans, and Talos provides the embodiment layer — abstracting hardware (or simulated hardware) so that Sophia's plans can drive real-world interaction. The system is designed to be situated: perceiving, reasoning, planning, and acting in a physical environment.
+Planning is a core capability *by design*. An `HCGPlanner` exists in the foundry that performs backward-chaining over REQUIRES/CAUSES edges to produce executable plans — but it is **not yet invoked anywhere in the running loop**, and a planner stub still co-exists with it (logos #403). Talos is intended as the embodiment layer — abstracting hardware (or simulated hardware) so that Sophia's plans can drive real-world interaction — and currently stands at a simulation scaffold. The system is *designed* to be situated: perceiving, reasoning, planning, and acting in a physical environment. (Aspirational; situated operation is Horizon 2, Goal 9.)
 
 ## Domains
 
@@ -27,11 +39,11 @@ Planning is a core capability. The HCGPlanner performs backward-chaining over RE
 
 ## Goals
 
-1. **Complete the cognitive loop** — in progress
-   The core perception → reasoning → action cycle works end-to-end (Hermes extracts entities/relations, Sophia stores and retrieves from HCG, context enriches LLM responses). Centralized Redis event bus (`logos_events`) provides the backbone. Ontology pub/sub distribution keeps Sophia and Hermes type-synced at runtime. The maintenance scheduler gives Sophia autonomous graph-reasoning triggers. KG maintenance work (entity resolution, type correction, relationship inference, ontology evolution) is how this loop becomes self-correcting. Expand with: entity resolution (#503), feedback processing, planning integration, multi-turn memory.
+1. **Complete the cognitive loop** — in progress (the spine of MTS)
+   The *ingestion* arc works end-to-end (Hermes extracts entities/relations, Sophia stores to HCG and retrieves context that enriches LLM responses); the centralized Redis event bus (`logos_events`) and runtime ontology pub/sub between Sophia and Hermes are live on main, and the maintenance scheduler is wired. **But the loop is not yet self-correcting or autonomous:** embeddings silently fail to persist at ingestion (the keystone bug, sophia#146 / logos#528), so the type classifier degrades to a fallback and emergence starves; feedback is a stub that logs and discards; the scheduler has essentially no reasoning jobs; and Sophia runs request/response, not as a persistent event-driven process. Closing this is the through-line of the six MTS sprints: stabilize the spine (Sprint 1) → feedback mutates the graph (Sprint 2) → orchestrator + event-driven loop (Sprint 3) → K-lines/curiosity/gain (Sprint 4) → memory + planning-in-loop (Sprint 5) → demonstrate (Sprint 6). See `docs/plans/2026-05-29-roadmap-to-mts.md`.
 
 2. **Grounding and physical knowledge** — research active (integration deferred)
-   Give Sophia intuitive physical common sense — the ability to recognize when something is physically ridiculous, or to anticipate what happens when a robot takes a corner too fast. This is what makes LOGOS fundamentally different from text-only systems: cognition grounded in experience, not language. The implementation approach is JEPA (Joint Embedding Predictive Architecture) models that learn physical/sensory representations without text, feeding into CWM-G. PoC exists in sophia (#76) with pluggable backend, tests, docs, and API shape validation. **Research is active:** the V-JEPA token-grid PoC (logos-workspace PR #4) ran 80+ experiments translating V-JEPA temporal tokens into CLIP space, achieving txt_R@1 = 0.371 (target 0.42). A universal embedding layer design (`docs/plans/2026-03-06-universal-embedding-layer-design.md`) defines the multi-head autoencoder architecture. **Integration into Sophia remains deferred** until the cognitive loop matures, but the research track is validating feasibility now.
+   Give Sophia intuitive physical common sense — the ability to recognize when something is physically ridiculous, or to anticipate what happens when a robot takes a corner too fast. This is what makes LOGOS fundamentally different from text-only systems: cognition grounded in experience, not language. The implementation approach is JEPA (Joint Embedding Predictive Architecture) models that learn physical/sensory representations without text, feeding into CWM-G. PoC exists in sophia (#76) with pluggable backend, tests, docs, and API shape validation. **Research is active:** the V-JEPA token-grid PoC (logos-workspace PR #4) ran 80+ experiments translating V-JEPA temporal tokens into CLIP space, achieving txt_R@1 = 0.371 (target 0.42). The design and plan are `docs/plans/2026-03-05-jepa-clip-translator-design.md` / `-plan.md`. **Integration into Sophia is Horizon 2** — deferred until MTS is reached and the cognitive loop matures — but the research track is validating feasibility now.
 
 3. **Flexible ontology** — in progress
    Replace rigid schema-typed nodes with a structure-typed model where meaning comes from IS_A edges and graph position. Core reified model is implemented (PR #490); ontology hierarchy restructured (#510). CWM-A, CWM-G, and CWM-E are semantically distinct aspects of the same graph — the current module-level separation (separate packages, raw Cypher) needs to become ontology-level (type definitions, HCG client, #496). Remaining: downstream repo updates (#460, #461), type_definition UUID migration (#515), capability catalog (#465).
@@ -39,11 +51,11 @@ Planning is a core capability. The HCGPlanner performs backward-chaining over RE
 4. **Memory and learning** — not started
    Transform LOGOS from a stateless system into one that learns from experience. Hierarchical memory (ephemeral → short-term → long-term), event-driven reflection, selective diary entries, episodic learning. Spec exists (#415), prerequisites need completing. The Redis event bus and maintenance scheduler landed as foundational infrastructure. Testing sanity (#416, priority:critical) must happen first.
 
-5. **Planning and execution** — in progress
-   Sophia reasons in order to act — whether that's answering a user's question ("how do I get to LA by tomorrow?") or driving a robot arm from point A to point B. The HCGPlanner does backward-chaining over REQUIRES/CAUSES edges to produce executable plans represented as Process nodes. Planner stub still exists alongside the real implementation (#403). As Talos matures, plans connect to real-world actuation. Blocked on flexible ontology downstream updates (#460).
+5. **Planning and execution** — early / mostly aspirational
+   Sophia should reason in order to act — whether that's answering a user's question ("how do I get to LA by tomorrow?") or driving a robot arm from point A to point B. An `HCGPlanner` exists in the foundry that does backward-chaining over REQUIRES/CAUSES edges to produce plans as Process nodes, **but it is not invoked anywhere in the running loop**, and a planner stub still co-exists with it (#403). Planning-in-loop — new knowledge enabling a goal triggers the planner — is **Sprint 5** of the MTS plan, gated on the feedback loop and memory tiers landing first; the planner-vs-stub reconciliation (#403/#464) is a decision deferred to that sprint. As Talos matures (Horizon 2), plans connect to real-world actuation. Downstream flexible-ontology updates (#460, #464) are prerequisites.
 
 6. **Embodiment via Talos** — paused
-   Talos abstracts hardware behind a consistent HAL. Current state is a simulation scaffold — `docs/proposed_docs/TALOS_IMPROVEMENTS.md` outlines the path to physics-backed simulation (ROS2/Gazebo/MuJoCo). Connects Sophia's plans to real-world actuation and perception feeds (camera frames, IMU, joint state) back into the cognitive loop. Correctly deprioritized until the cognitive layer is solid.
+   Talos abstracts hardware behind a consistent HAL. Current state is a simulation scaffold — `docs/TALOS_IMPROVEMENTS.md` outlines the path to physics-backed simulation (ROS2/Gazebo/MuJoCo). Connects Sophia's plans to real-world actuation and perception feeds (camera frames, IMU, joint state) back into the cognitive loop. Correctly deprioritized until the cognitive layer is solid.
 
 7. **Infrastructure and observability** — in progress
    CI discipline tooling (branch naming, issue linkage) landed across all repos. Reusable workflows pinned to ci/v2. Centralized Redis and `logos_events` package provide the event backbone. Port standardization completed. Docker stacks aligned. OTel instrumentation exists across services via `logos_observability`; Apollo OTel integration complete (PR #156, closing #340, #341, #342). Gaps remain in endpoint-level spans (#335, #338), cross-service testing (#321), and Hermes OTel documentation (#339). Remaining: standardize repos (#433), developer scripts (#409), test data seeder (#481).
@@ -63,7 +75,13 @@ Planning is a core capability. The HCGPlanner performs backward-chaining over RE
 
 ## Current Priorities
 
-1. Cognitive loop expansion (entity resolution, feedback processing, KG maintenance execution)
-2. KG maintenance stories (#503, #504, #505, #506) — #503 has full design + implementation plan ready
-3. Flexible ontology downstream propagation (#460, #461, #515)
-4. Infrastructure hardening (remaining standardization, coverage)
+Driven by **MTS Sprint 1 — "Make the built spine actually run & be trusted"**
+(`docs/plans/2026-05-29-roadmap-to-mts.md`). Critical path: logos#528 → sophia#146 → live-verified #505.
+
+1. **Keystone:** fix embedding persistence (logos#528 upsert-by-uuid + schema, then sophia#146 warn-only swallow) — without this the classifier and emergence both starve.
+2. Finish & merge #505 emergent type discovery, live-verified on real infra.
+3. De-vacuum integration tests + run them in CI (logos#529); add Redis to CI (logos #526).
+4. Cross-repo foundry sync (apollo/talos → v0.7.1, logos#530); FeedbackConfig port fix (sophia #142).
+
+Sprint 2+ then closes the feedback loop, builds the orchestrator/event-driven loop,
+and adds the cognitive mechanisms — see the roadmap for the full six-sprint arc.


### PR DESCRIPTION
Refreshes the ecosystem-level **workspace** docs to match the current code state and the **Minimum Thinking Sophia (MTS)** framing, anchored on the 2026-05-29 code-grounded audit and the MTS roadmap (`docs/plans/2026-05-29-roadmap-to-mts.md`, `docs/plans/2026-05-30-issue-realignment.md`). This is the S1-08 doc-refresh ticket.

## What changed (3 files, docs only)

**`docs/STATUS.md`** — rewritten around the real state:
- One-paragraph picture: **foundation strong, cognitive core largely spec**; ~35–40% of the near-term vision.
- **Keystone finding** surfaced: embeddings silently fail to persist — verified in current code at `sophia/.../proposal_processor.py:519-524` (warn-only `try/except`) and `logos/logos_hcg/sync.py:155,315,365` (insert-only against an `auto_id` PK). Tracked as **sophia#146 depends-on logos#528**.
- Added the **six-sprint MTS map** and the active **Sprint-1 ticket table** (logos#528, sophia#146, logos#529, logos#530, logos#531, #505).
- Foundry bumped to v0.7.1; empty-Apollo-dashboard schema drift noted (logos #496, Sprint 6).

**`docs/VISION.md`** — reconciled with MTS:
- MTS reading-frame banner at the top; planning/embodiment prose marked **aspirational** (the `HCGPlanner` exists in the foundry but is **not invoked in any running loop**).
- Goal 1 rewritten around the six-sprint arc; Goal 5 reframed as early/aspirational.
- Fixed two **stale design-doc paths** (`2026-03-06-universal-embedding-layer-design.md` → `2026-03-05-jepa-clip-translator-design.md`; `docs/proposed_docs/TALOS_IMPROVEMENTS.md` → `docs/TALOS_IMPROVEMENTS.md`).
- Current Priorities re-pointed at the Sprint-1 critical path.

**`docs/COGNITIVE_LOOP.md`** — corrected stale claims + MTS map:
- Scope + keystone caveat header (the documented 'embedding written to Milvus' side effects are currently a no-op until the keystone lands).
- Corrected the now-stale **'ProposalBuilder has zero tests'** (now 6 unit tests) and **'bus carries no inter-service traffic'** (sophia #501 pub/sub is live on main).
- Flagged the **vacuous `{id: $proposal_id}` integration test** at `test_hermes_ingestion_integration.py:139` (logos#529) as why the keystone bug went undetected.
- Mapped the loop-expansion axes onto the six MTS sprints.

## Verification

All claims were checked against the code on `main` plus the unmerged `feat/505-*` frontier branches (not against prose). All in-repo doc-path references resolve except the two MTS anchor plans, which live on `docs/mts-roadmap-and-realignment-plans` (commit 797ac91) and land on main alongside this work.

## Deferred (out of scope for this PR)

Per the ticket, the **vault LOGOS landing/narrative** refresh (old 18000/28000 ports + dead monorepo paths → re-point at the audit + roadmap) is **not** done here — the vault is edited via a separate tool, not this repo. Left as a manual follow-up for the maintainer; called out in STATUS.md.

No infra needed; docs-only, no executable tests.

Part of c-daly/logos#531